### PR TITLE
Reduce Fisher-Yates random test to 50 sequences

### DIFF
--- a/test/permute/fisher_yates.test.cpp
+++ b/test/permute/fisher_yates.test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Fisher-Yates: Integer cases", "[fisher-yates]") {
 
 TEST_CASE("Fisher-Yates: Doesn't remove or duplate elements", "[fisher-yates]") {
     srand(0);
-    for(auto i = 0; i < 1000; ++i) {
+    for(auto i = 0; i < 50; ++i) {
         std::vector<int> values(1000);
         std::iota(values.begin(), values.end(), 0);
 


### PR DESCRIPTION
<!-- Don't add anything up here. Try to only add stuff after the description. -->

#### Type of change
- [x] Small bug fix
- [ ] New feature
- [ ] Breaking change

#### Checklist
- [x] An issue has been made for this pull request
- [x] Your pull request is merging into `master`
- [x] Cleanup commits using `git rebase`
- [x] Branch name starts with `fix/` or `feature/`
- [x] All tests pass locally
- [x] You have updated the README implementation table if you added a new data-structure/algorithm or added tests.

<!-- Replace XXXX with the issue number this resolves. -->
Closes #27 

#### Description

<!-- Add the description/changes of your pull request here. -->
Reduced the number of random sequences tested in fisher-yates from 1000 to 50 to speed up tests.
